### PR TITLE
Added Record Id Check at Prompt

### DIFF
--- a/eodms_cli.py
+++ b/eodms_cli.py
@@ -1736,7 +1736,28 @@ class Prompter:
                 sar_tb.ingest_request()
             else:
                 inputs = self.ask_st_images(input_val)
-                self.params['input_val'] = inputs
+
+                coll_id, ids = inputs.split(':')
+                # If Order Keys are entered, check if they exist
+                if inputs.find("_") > -1:
+                    ord_keys = ids.split('|')
+                    rec_ids = self.eod.get_record_ids(coll_id, ord_keys)
+
+                    if len(rec_ids) == 0:
+                        err_msg = f"No images could be found with Order Keys: "\
+                                f"{', '.join(ord_keys)}."
+                        self.eod.logger.error(err_msg)
+                        # self.print_support(err_msg)
+                        self.eod.print_msg(err_msg, heading='error')
+                        self.eod.exit_cli(1)
+                else:
+                    rec_ids = ids.split('|')
+
+                print(f"\nSubmitting images with Record Ids: " \
+                      f"{', '.join(rec_ids)}")
+
+                self.params['input_val'] = {"collection_id": coll_id, 
+                                            "record_ids": rec_ids}
 
                 # sar_tb = self.ask_st(self.params['input_val'])
                 sar_tb = self.ask_st()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1237,6 +1237,22 @@ class EodmsUtils:
 
     #     return displayed_fields
 
+    def get_record_ids(self, coll_id, order_keys):
+
+        if not isinstance(order_keys, list):
+            order_keys = [order_keys]
+        
+        record_ids = []
+        for ok in order_keys:
+            filters = {'Order Key': ('=', ok)}
+            self.eodms_rapi.search(coll_id, filters)
+
+            res = self.eodms_rapi.get_results()
+            if len(res) > 0:
+                record_ids = [r.get('recordId') for r in res]
+
+        return record_ids
+
     def get_image_from_order(self, order):
         """
         Gets an image from the RAPI based on an order into an image.Image object.
@@ -2604,28 +2620,8 @@ class EodmsProcess(EodmsUtils):
         in_vals = params.get('input_val')
         priority = params.get('priority')
 
-        coll_id, ids = in_vals.split(':')
-
-        if ids.find("_") > -1:
-            ord_keys = ids.split('|')
-            for ok in ord_keys:
-                filters = {'Order Key': ('=', ok)}
-                self.eodms_rapi.search(coll_id, filters)
-
-            res = self.eodms_rapi.get_results()
-            if len(res) > 0:
-                record_ids = [r.get('recordId') for r in res]
-
-                # print(f"res: {res}")
-                # answer = input("Press enter...")
-        else:
-            record_ids = ids.split('|')
-
-        # print(f"record_ids: {record_ids}")
-        # answer = input("Press enter...")
-
-        sar_toolbox.set_coll_id(coll_id)
-        sar_toolbox.set_record_ids(record_ids)
+        sar_toolbox.set_coll_id(in_vals.get('collection_id'))
+        sar_toolbox.set_record_ids(in_vals.get('record_ids'))
 
         start_str = self._set_result_fn()
         self.logger.info(f"Process start time: {start_str}")


### PR DESCRIPTION
When running Process 6 (SAR Toolbox Ordering), script checks for Record Id when an Order Key is entered instead of after all prompts.

	modified:   eodms_cli.py
	modified:   scripts/utils.py